### PR TITLE
refactor: replace retired bobleesj.utils dependency with cifkit

### DIFF
--- a/core/util/formula_parser.py
+++ b/core/util/formula_parser.py
@@ -1,6 +1,6 @@
 import re
 
-from bobleesj.utils.sources import mendeleev
+from cifkit.sources import mendeleev
 
 
 def get_normalized_formula(formula):

--- a/news/migrate-to-cifkit.rst
+++ b/news/migrate-to-cifkit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Replace the retired ``bobleesj.utils`` dependency with ``cifkit``>=1.2.0, which now ships the Oliynyk database, ``Formula`` parser, ``ElementSorter``, and elemental data sources; imports migrate by replacing ``bobleesj.utils`` with ``cifkit``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cifkit
+cifkit>=1.2.0
 click
 gemmi
 matplotlib
@@ -7,4 +7,3 @@ openpyxl
 pandas
 scipy
 jsondiff
-bobleesj.utils


### PR DESCRIPTION
### What problem does this PR address?

cifkit 1.2.1 (now on PyPI) ships the elemental data modules formerly in bobleesj.utils, which is being deprecated and archived. This swaps imports (`bobleesj.utils` -> `cifkit`), dedupes requirements to `cifkit>=1.2.0`, and updates user-facing docs. Historical CHANGELOG entries are left untouched.

### What should the reviewer(s) do?

Merge.

Verified: import smoke test passes against cifkit 1.2.x (no test suite in this repo).